### PR TITLE
Fixing documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ csrf.secret(function (err, secret) {
 
 Synchronous version of `csrf.secret()`
 
-#### var token = csrf.token(secret)
+#### var token = csrf.create(secret)
 
 Create a CSRF token based on a `secret`.
 This is the token you pass to clients.


### PR DESCRIPTION
`csrf.token()` should be `csrf.create()`