### PR TITLE
Use double HMAC comparision for tokens - upgrade scmp to tsscmp

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
  */
 
 var rndm = require('rndm')
-var scmp = require('scmp')
+var tsscmp = require('tsscmp')
 var uid = require('uid-safe')
 var crypto = require('crypto')
 var escape = require('base64-url').escape
@@ -135,5 +135,5 @@ Tokens.prototype.verify = function verify (secret, token) {
   var salt = token.substr(0, index)
   var expected = this._tokenize(secret, salt)
 
-  return scmp(token, expected)
+  return tsscmp(token, expected)
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "base64-url": "1.2.2",
     "rndm": "1.2.0",
     "tsscmp": "1.0.2",
-    "uid-safe": "2.1.0"
+    "uid-safe": "2.1.1"
   },
   "devDependencies": {
     "bluebird": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "base64-url": "1.2.2",
     "rndm": "1.2.0",
-    "scmp": "1.0.0",
-    "uid-safe": "2.1.1"
+    "tsscmp": "1.0.2",
+    "uid-safe": "2.1.0"
   },
   "devDependencies": {
     "bluebird": "3.4.0",


### PR DESCRIPTION
Constant-time string-comparison approach used by [scmp](https://www.npmjs.com/package/scmp) is still vulnerable to [timing attacks](https://codahale.com/a-lesson-in-timing-attacks/) on node.  [Here](https://github.com/nodejs/node-v0.x-archive/issues/8560#issuecomment-59793384) is relative recent discussion by node core team. The recommendation is to use [double HMAC comparison](https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2011/february/double). 

As a fix upgrade to [tsscmp](https://www.npmjs.com/package/tsscmp) that uses the recommended approach implemented in the [latest version of node](https://github.com/nodejs/node/pull/3073)