### PR TITLE
Add type definition for typescript

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+  * Include a TypeScript definition file
   * deps: tsscmp@1.0.6
     - Use `crypto.timingSafeEqual` when available
   * deps: uid-safe@2.1.5

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,48 @@
+declare class Tokens {
+  /**
+   * Token generation/verification class.
+   */
+  constructor(options?: Tokens.Options);
+
+  /**
+   * Create a new CSRF token.
+   */
+  create(secret: string): string;
+
+  /**
+   * Create a new secret key.
+   */
+  secret(): Promise<string>;
+
+  /**
+   * Create a new secret key.
+   */
+  secret(callback: Tokens.SecretCallback): void;
+
+  /**
+   * Create a new secret key synchronously.
+   */
+  secretSync(): string;
+
+  /**
+   * Verify if a given token is valid for a given secret.
+   */
+  verify(secret: string, token: string): boolean;
+}
+
+declare namespace Tokens {
+  export type SecretCallback = (err: Error | null, secret: string) => void;
+
+  export interface Options {
+    /**
+     * The string length of the salt (default: 8)
+     */
+    saltLength?: number;
+    /**
+     * The byte length of the secret key (default: 18)
+     */
+    secretLength?: number;
+  }
+}
+
+export = Tokens;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "LICENSE",
     "HISTORY.md",
     "README.md",
+    "index.d.ts",
     "index.js"
   ],
   "engines": {


### PR DESCRIPTION
By adding this typescript definition, it will make it easier for developers who use typescript to use this module in their projects.  Thankfully, this project was beautifully commented so creating this definition file was easy.  But it would be awesome if I didn't have to even look at the source file and my IDE would just pickup the definitions of this node module automatically from a definition file in the module itself.